### PR TITLE
Fixed bug in division_tree

### DIFF
--- a/Qommunity/searchers/hierarchical_community_searcher/hierarchical_community_searcher.py
+++ b/Qommunity/searchers/hierarchical_community_searcher/hierarchical_community_searcher.py
@@ -84,7 +84,7 @@ class HierarchicalCommunitySearcher:
 
                 # Remove the last division if it repeats itself
                 if higher_list_elements == lower_list_elements:
-                    division_tree.pop(len(division_tree) - 1)
+                    division_tree.pop(-1)
 
             if division_tree and return_modularities:
                 division_modularities = []


### PR DESCRIPTION
Previous state - incorrect result:
![obraz](https://github.com/user-attachments/assets/5645bf1b-836c-4b64-a660-e0f31b2cad72)

Current state - correct result:
![obraz](https://github.com/user-attachments/assets/5882ee15-f213-4298-85e5-f32d1dfc7959)


